### PR TITLE
fix: Use `ResultSet.getObject` to respect nullable columns of the basic SQL data types

### DIFF
--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -166,9 +166,6 @@ func jdbcGet(t ktType, idx int) string {
 	if t.IsInstant() {
 		return fmt.Sprintf(`results.getTimestamp(%d).toInstant()`, idx)
 	}
-	if t.IsBigDecimal() {
-		return fmt.Sprintf(`results.getBigDecimal(%d)`, idx)
-	}
 
 	var nullCast string
 	if t.IsNull {
@@ -364,10 +361,6 @@ func (t ktType) IsInstant() bool {
 
 func (t ktType) IsUUID() bool {
 	return t.Name == "UUID"
-}
-
-func (t ktType) IsBigDecimal() bool {
-	return t.Name == "java.math.BigDecimal"
 }
 
 func makeType(req *plugin.GenerateRequest, col *plugin.Column) ktType {

--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -175,7 +175,7 @@ func jdbcGet(t ktType, idx int) string {
 		nullCast = "?"
 	}
 
-	return fmt.Sprintf(`results.getObject(%d) as%s %s`, idx, nullCast, t.Name)
+	return fmt.Sprintf(`results.getObject(%d) as %s%s`, idx, t.Name, nullCast)
 }
 
 func (v QueryValue) ResultSet() string {

--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -166,17 +166,16 @@ func jdbcGet(t ktType, idx int) string {
 	if t.IsInstant() {
 		return fmt.Sprintf(`results.getTimestamp(%d).toInstant()`, idx)
 	}
-	if t.IsUUID() {
-		var nullCast string
-		if t.IsNull {
-			nullCast = "?"
-		}
-		return fmt.Sprintf(`results.getObject(%d) as%s %s`, idx, nullCast, t.Name)
-	}
 	if t.IsBigDecimal() {
 		return fmt.Sprintf(`results.getBigDecimal(%d)`, idx)
 	}
-	return fmt.Sprintf(`results.get%s(%d)`, t.Name, idx)
+
+	var nullCast string
+	if t.IsNull {
+		nullCast = "?"
+	}
+
+	return fmt.Sprintf(`results.getObject(%d) as%s %s`, idx, nullCast, t.Name)
 }
 
 func (v QueryValue) ResultSet() string {

--- a/internal/core/imports.go
+++ b/internal/core/imports.go
@@ -86,6 +86,9 @@ func (i *Importer) modelImports() [][]string {
 	if i.usesType("UUID") {
 		std["java.util.UUID"] = struct{}{}
 	}
+	if i.usesType("BigDecimal") {
+		std["java.math.BigDecimal"] = struct{}{}
+	}
 
 	stds := make([]string, 0, len(std))
 	for s := range std {
@@ -119,6 +122,9 @@ func stdImports(uses func(name string) bool) map[string]struct{} {
 	}
 	if uses("UUID") {
 		std["java.util.UUID"] = struct{}{}
+	}
+	if uses("BigDecimal") {
+		std["java.math.BigDecimal"] = struct{}{}
 	}
 
 	return std

--- a/internal/core/postgresql_type.go
+++ b/internal/core/postgresql_type.go
@@ -36,7 +36,7 @@ func postgresType(req *plugin.GenerateRequest, col *plugin.Column) (string, bool
 		return "Float", false
 
 	case "pg_catalog.numeric":
-		return "java.math.BigDecimal", false
+		return "BigDecimal", false
 
 	case "bool", "pg_catalog.bool":
 		return "Boolean", false


### PR DESCRIPTION
## Description
Use `ResultSet.getObject` for the generation code of sqlc-gen-kotlin to respect nullable columns of the basic SQL data types.

Fixes #20

## Details

`java.sql.ResultSet.get{SpecificType}`, such as `ResultSet.getInt`, `ResultSet.getBoolean`, returns the zero value of each types when the selected value is SQL NULL. 

> "Returns: the column value; if the value is SQL NULL, the value returned is false."

https://docs.oracle.com/en/java/javase/21/docs/api/java.sql/java/sql/ResultSet.html#getBoolean(int)

On the other hand, `ResultSet.getObject` returns null when the selected value is SQL NULL. 

https://docs.oracle.com/en/java/javase/21/docs/api/java.sql/java/sql/ResultSet.html#getObject(int,java.lang.Class)

Both [pgjdbc/PgResultSet.getObject](https://github.com/pgjdbc/pgjdbc/blob/a4089461cacc5e6f0168ab95bf2ff7d253de8336/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java#L3044), [mysql-connector-j/ResultSetImpl](https://github.com/mysql/mysql-connector-j/blob/805f872a57875f311cb82487efcfb070411a3fa0/src/main/user-impl/java/com/mysql/cj/jdbc/result/ResultSetImpl.java#L1112) implements `ResultSet.getObject` with nullable column handling and basic SQL data types detection, so I think sqlc-gen-kotlin should be use it and rely on driver implementations.